### PR TITLE
 Add pow and binary_accumulate 

### DIFF
--- a/number_theory/numeric.h
+++ b/number_theory/numeric.h
@@ -1,9 +1,13 @@
 #ifndef NUMBER_THEORY_NUMERIC_H_
 #define NUMBER_THEORY_NUMERIC_H_
 
+#include <functional>
 #include <limits>
 #include <numeric>
+#include <type_traits>
 #include <utility>
+
+#include "number_theory/utility.h"
 
 // Common numeric functions.
 
@@ -41,6 +45,45 @@ std::pair<T, T> exgcd(T a, T b) {
   }
 
   return std::make_pair(xa, ya);
+}
+
+// Computes the value of |base| raised to an integer power |exponent|.
+// This version of overload uses binary exponentiation technique to compute in
+// O(log |exponent|) time.
+template <class T,
+          class U,
+          std::enable_if_t<std::numeric_limits<U>::is_integer, bool> = true>
+T pow(const T &base, U exponent) {
+  using Pair_TT = std::pair<T, T>;
+  using Unsigned_U = std::make_unsigned_t<U>;
+
+  auto update = [](bool bit, Pair_TT &state) {
+    // At the n-th bit of |exponent|, |power| is |base|^(2^n), and
+    // |result| is the answer for the first n bits of |exponent|.
+    auto &[result, power] = state;
+    if (bit)
+      result *= power;
+    power *= power;
+  };
+
+  Unsigned_U abs_exp = std::abs(exponent);
+  Pair_TT state = binary_accumulate<Unsigned_U, Pair_TT>(
+      abs_exp, std::make_pair(1, base), update);
+  T result = std::move(state.first);
+
+  // Return the inverse of the result if the exponent is negative.
+  if (exponent < 0)
+    return 1 / result;
+  return result;
+}
+
+// Computes the value of |base| raised to a non-integer power |exponent|.
+// This version of overload is the same as std::pow.
+template <class T,
+          class U,
+          std::enable_if_t<!std::numeric_limits<U>::is_integer, bool> = true>
+auto pow(T base, U exponent) -> decltype(std::pow(base, exponent)) {
+  return std::pow(base, exponent);
 }
 
 }  // namespace number_theory

--- a/number_theory/utility.h
+++ b/number_theory/utility.h
@@ -1,0 +1,35 @@
+#ifndef NUMBER_THEORY_UTILITY_H_
+#define NUMBER_THEORY_UTILITY_H_
+
+#include <functional>
+#include <limits>
+
+// Public utility functions.
+
+namespace number_theory {
+
+// Accumulates values according to the binary representation of |binary|.
+// If |binary| is negative, the two's complement representation will be used.
+// For each bit of |binary|, from lower to higher, it applies |operation| to
+// accumulate the values. The initial value is |initial_value|.
+// As an example, when |operation| is addition, it becomes a popcount.
+template <class T, class U>
+U binary_accumulate(T binary,
+                    const U &initial_value,
+                    std::function<void(bool, U &)> operation) {
+  static_assert(std::numeric_limits<T>::is_integer,
+                "binary_accumulate argument |binary| must be an integer");
+
+  T current = binary;
+  U result = initial_value;
+  while (current != 0) {
+    bool bit = (current % 2) != 0;
+    current /= 2;
+    operation(bit, result);
+  }
+  return result;
+}
+
+}  // namespace number_theory
+
+#endif  // NUMBER_THEORY_UTILITY_H_


### PR DESCRIPTION
The pow function is overloaded for integer and non-integer exponent.
It uses binary exponentiation for integer exponent and uses std::pow
for non-integer exponent.

A utility function, binary_accumulate, is extracted. It can be used by other
algorithms in the future, such as computing (a*b)%m without overflow.