### PR TITLE
Add a workflow to check formatting on PRs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Chromium
+PointerAlignment: Right

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,12 @@
+name: checks
+
+on: [pull_request]
+
+jobs:
+  coding-style:
+    name: Code Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run clang-format style check.
+        uses: jidicula/clang-format-action@v4.4.1


### PR DESCRIPTION
These automated checks will help us to detect code formatting issues on pull requests.

It would be better if we also add [clang-tidy-review](https://github.com/marketplace/actions/clang-tidy-review) action to lint the code. However, it requires a compilation database which we currently do not have. It also currently does not support `.clang-tidy` files, but it seems they are planning to add it with ZedThree/clang-tidy-review#9.