### PR TITLE
Include cmath to have std::pow available

### DIFF
--- a/number_theory/numeric.h
+++ b/number_theory/numeric.h
@@ -1,6 +1,7 @@
 #ifndef NUMBER_THEORY_NUMERIC_H_
 #define NUMBER_THEORY_NUMERIC_H_
 
+#include <cmath>
 #include <functional>
 #include <limits>
 #include <numeric>


### PR DESCRIPTION
I realized that `std::pow` was not recognized in the scope thanks to `ycm` plugin. It can still compile since things can be included implicitly, but we should include what we use. We also need some automated help to be aware of both included-but-not-used headers and not-included-but-used headers. Testing and clang-tidy will help us resolve this hopefully.