### PR TITLE
Forward bit_length to std::bit_width

### DIFF
--- a/number_theory/utility.h
+++ b/number_theory/utility.h
@@ -38,9 +38,7 @@ template <class T>
 constexpr std::size_t bit_length(T number) {
   static_assert(std::numeric_limits<T>::is_integer,
                 "bit_length argument must be an integer.");
-  using Unsigned_T = std::make_unsigned_t<T>;
-  Unsigned_T abs_number = std::abs(number);
-  return std::numeric_limits<Unsigned_T>::digits - std::countl_zero(abs_number);
+  return std::bit_width(number);
 }
 
 }  // namespace number_theory

--- a/number_theory/utility.h
+++ b/number_theory/utility.h
@@ -38,7 +38,7 @@ template <class T>
 constexpr std::size_t bit_length(T number) {
   static_assert(std::numeric_limits<T>::is_integer,
                 "bit_length argument must be an integer.");
-  return std::bit_width(number);
+  return std::bit_width(std::abs(number));
 }
 
 }  // namespace number_theory


### PR DESCRIPTION
This commit replaces `bit_length` implementation with `std::bit_width`.
According to the documentation `std::bit_width(x)` is equal to
`std::numeric_limits<T>::digits - std::countl_zero(x)`.