### PR TITLE
Return opposite numbers when exgcd get a negative result

### DIFF
--- a/number_theory/numeric.h
+++ b/number_theory/numeric.h
@@ -46,6 +46,8 @@ std::pair<T, T> exgcd(T a, T b) {
     ta = tb, tb = tc;
   }
 
+  if (ta < 0)
+    return std::make_pair(-xa, -ya);
   return std::make_pair(xa, ya);
 }
 


### PR DESCRIPTION
The gcd function always returns a non-negative number, but exgcd may produce x*a+y*b<0. So return opposite numbers of (x,y) to fix it.