### PR TITLE
Remove bit_length

### DIFF
--- a/number_theory/utility.h
+++ b/number_theory/utility.h
@@ -1,11 +1,8 @@
 #ifndef NUMBER_THEORY_UTILITY_H_
 #define NUMBER_THEORY_UTILITY_H_
 
-#include <bit>
 #include <functional>
 #include <limits>
-#include <numeric>
-#include <type_traits>
 
 // Public utility functions.
 
@@ -32,16 +29,6 @@ U binary_accumulate(T binary,
     operation(bit, result);
   }
   return result;
-}
-
-// Returns the number of bits of an integer.
-template <class T>
-constexpr std::size_t bit_length(T number) {
-  static_assert(std::numeric_limits<T>::is_integer,
-                "bit_length argument must be an integer.");
-  using Unsigned_T = std::make_unsigned_t<T>;
-  Unsigned_T abs_number = std::abs(number);
-  return std::numeric_limits<Unsigned_T>::digits - std::countl_zero(abs_number);
 }
 
 }  // namespace number_theory


### PR DESCRIPTION
The bit_length function is removed because it can be replaced by
std::bit_width.