### PR TITLE
Fix integer overflow in exgcd

### DIFF
--- a/number_theory/numeric.h
+++ b/number_theory/numeric.h
@@ -27,16 +27,16 @@ std::pair<T, T> exgcd(T a, T b) {
       std::numeric_limits<T>::is_integer && std::numeric_limits<T>::is_signed,
       "exgcd arguments must be signed integers");
 
-  // xa * a + ya * b == ta
-  // xb * b + yb * b == tb
-  T ta = a, tb = b;
+  // xa * abs(a) + ya * abs(b) == ta
+  // xb * abs(b) + yb * abs(b) == tb
+  auto ta = unsigned_abs(a), tb = unsigned_abs(b);
   T xa = 1, ya = 0;
   T xb = 0, yb = 1;
 
   while (tb != 0) {
     T q = ta / tb;
 
-    // xc * a + yc * b == tc
+    // xc * abs(a) + yc * abs(b) == tc
     T tc = ta - q * tb;
     T xc = xa - q * xb;
     T yc = ya - q * yb;
@@ -46,9 +46,7 @@ std::pair<T, T> exgcd(T a, T b) {
     ta = tb, tb = tc;
   }
 
-  if (ta < 0)
-    return std::make_pair(-xa, -ya);
-  return std::make_pair(xa, ya);
+  return std::make_pair(sign(a) * xa, sign(b) * ya);
 }
 
 // Computes the value of |base| raised to an integer power |exponent|.

--- a/number_theory/numeric_unittest.cpp
+++ b/number_theory/numeric_unittest.cpp
@@ -17,8 +17,8 @@ void test_exgcd(T a, T b) {
   auto [x, y] = exgcd(a, b);
   if (a != 0 && b != 0) {
     // Bézout's identity
-    ASSERT_LE(std::abs(x), std::abs(b));
-    ASSERT_LE(std::abs(y), std::abs(a));
+    ASSERT_LE(unsigned_abs(x), unsigned_abs(b));
+    ASSERT_LE(unsigned_abs(y), unsigned_abs(a));
   }
   ASSERT_EQ(x * a + y * b, std::gcd(a, b));
 }
@@ -41,6 +41,11 @@ TEST(NumericTest, ExGCD) {
     int64_t b = rand_gen(rand_engine);
     test_exgcd(a, b);
   }
+  // test overflow
+  test_exgcd<int32_t>(std::numeric_limits<int32_t>::min(),
+                      std::numeric_limits<int32_t>::max());
+  test_exgcd<int64_t>(std::numeric_limits<int64_t>::min(),
+                      std::numeric_limits<int64_t>::max());
 }
 
 }  // namespace number_theory

--- a/number_theory/numeric_unittest.cpp
+++ b/number_theory/numeric_unittest.cpp
@@ -42,10 +42,10 @@ TEST(NumericTest, ExGCD) {
     test_exgcd(a, b);
   }
   // test overflow
-  test_exgcd<int32_t>(std::numeric_limits<int32_t>::min(),
-                      std::numeric_limits<int32_t>::max());
-  test_exgcd<int64_t>(std::numeric_limits<int64_t>::min(),
-                      std::numeric_limits<int64_t>::max());
+  test_exgcd(std::numeric_limits<int32_t>::min(),
+             std::numeric_limits<int32_t>::max());
+  test_exgcd(std::numeric_limits<int64_t>::min(),
+             std::numeric_limits<int64_t>::max());
 }
 
 }  // namespace number_theory

--- a/number_theory/numeric_unittest.cpp
+++ b/number_theory/numeric_unittest.cpp
@@ -42,10 +42,12 @@ TEST(NumericTest, ExGCD) {
     test_exgcd(a, b);
   }
   // test overflow
-  test_exgcd(std::numeric_limits<int32_t>::min(),
-             std::numeric_limits<int32_t>::max());
-  test_exgcd(std::numeric_limits<int64_t>::min(),
-             std::numeric_limits<int64_t>::max());
+  test_exgcd(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+  test_exgcd(std::numeric_limits<int>::max(), std::numeric_limits<int>::min());
+  test_exgcd(std::numeric_limits<int>::max(), 1);
+  test_exgcd(std::numeric_limits<int>::min(), 1);
+  test_exgcd(1, std::numeric_limits<int>::max());
+  test_exgcd(1, std::numeric_limits<int>::min());
 }
 
 }  // namespace number_theory

--- a/number_theory/utility.h
+++ b/number_theory/utility.h
@@ -32,15 +32,12 @@ U binary_accumulate(T binary,
   return result;
 }
 
-// Returns the sign of the integer |x|.
+// Returns the sign of the number |x|.
 // If x = 0, sign(x) = 0.
 // If x > 0, sign(x) = 1.
 // If x < 0, sign(x) = -1.
 template <class T>
 constexpr int sign(T x) {
-  static_assert(std::numeric_limits<T>::is_integer,
-                "sign argument |x| must be an integer");
-
   if (x == 0)
     return 0;
   return x > 0 ? 1 : -1;
@@ -50,17 +47,12 @@ constexpr int sign(T x) {
 //
 // This can be useful because std::abs doesn't support unsigned integers, and
 // std::abs(std::numeric_limits<T>::min()) is undefined.
-template <class T, class U = std::make_unsigned_t<T>>
-constexpr U unsigned_abs(T x) {
+template <class T>
+constexpr std::make_unsigned_t<T> unsigned_abs(T x) {
   static_assert(std::numeric_limits<T>::is_integer,
-                "unsigned_abs argument |x| must be an integer");
-  static_assert(std::is_unsigned<U>::value,
-                "unsigned_abs result type must be unsigned.");
-  static_assert(sizeof(U) >= sizeof(T),
-                "unsigned_abs result type must be "
-                "at least as wide as the input type.");
+                "unsigned_abs argument |x| must be an integer.");
 
-  U y = static_cast<U>(x);
+  auto y = static_cast<std::make_unsigned_t<T>>(x);
   return x < 0 ? -y : y;
 }
 

--- a/number_theory/utility.h
+++ b/number_theory/utility.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <limits>
+#include <type_traits>
 
 // Public utility functions.
 
@@ -29,6 +30,36 @@ U binary_accumulate(T binary,
     operation(bit, result);
   }
   return result;
+}
+
+// Returns the sign of the integer |x|.
+// If x = 0, sign(x) = 0.
+// If x > 0, sign(x) = 1.
+// If x < 0, sign(x) = -1.
+template <class T>
+constexpr int sign(T x) {
+  static_assert(std::numeric_limits<T>::is_integer,
+                "sign argument |x| must be an integer");
+  if (x == 0)
+    return 0;
+  return x > 0 ? 1 : -1;
+}
+
+// Returns the absolute value of the integer |x| in an unsigned type.
+//
+// This can be useful because std::abs doesn't support unsigned integers, and
+// std::abs(std::numeric_limits<T>::min()) is undefined.
+template <class T, class U = std::make_unsigned_t<T>>
+constexpr U unsigned_abs(T x) {
+  static_assert(std::numeric_limits<T>::is_integer,
+                "unsigned_abs argument |x| must be an integer");
+  static_assert(std::is_unsigned<U>::value,
+                "unsigned_abs result type must be unsigned.");
+  static_assert(sizeof(U) >= sizeof(T),
+                "unsigned_abs result type must be "
+                "at least as wide as the input type.");
+  U y = static_cast<U>(x);
+  return x < 0 ? -y : y;
 }
 
 }  // namespace number_theory

--- a/number_theory/utility.h
+++ b/number_theory/utility.h
@@ -40,6 +40,7 @@ template <class T>
 constexpr int sign(T x) {
   static_assert(std::numeric_limits<T>::is_integer,
                 "sign argument |x| must be an integer");
+
   if (x == 0)
     return 0;
   return x > 0 ? 1 : -1;
@@ -58,6 +59,7 @@ constexpr U unsigned_abs(T x) {
   static_assert(sizeof(U) >= sizeof(T),
                 "unsigned_abs result type must be "
                 "at least as wide as the input type.");
+
   U y = static_cast<U>(x);
   return x < 0 ? -y : y;
 }


### PR DESCRIPTION
The old exgcd can overflow when its arguments are close to the max/min
of the signed integer type. So we convert the arguments to unsigned
integers before computation. This will make sure the value of ta and tb
always decrease in iterations.

This also introduces the sign and unsigned_abs utility functions.