### PR TITLE
Prefer typename over class in templates

### DIFF
--- a/number_theory/modular.h
+++ b/number_theory/modular.h
@@ -19,7 +19,7 @@ namespace {
 // Returns the equivalent element of |x| in the ring of integers modulo
 // |modulus|. The result |y| should statisfy 0 <= y < modulus, and
 // y = k*modulus + x for some integer k.
-template <class T,
+template <typename T,
           std::enable_if_t<std::numeric_limits<T>::is_integer, bool> = true>
 constexpr T normalize(T x, T modulus) {
   T y = std::move(x);
@@ -31,7 +31,7 @@ constexpr T normalize(T x, T modulus) {
   return y;
 }
 
-template <class T>
+template <typename T>
 struct ModulusWrapper {
   using type = T;
   T value;

--- a/number_theory/modular_unittest.cpp
+++ b/number_theory/modular_unittest.cpp
@@ -10,7 +10,7 @@
 namespace tql {
 namespace number_theory {
 
-template <class T>
+template <typename T>
 void test_modular_basic() {
   using Mod10 = Modular<T(10)>;
   static_assert(std::is_same<typename Mod10::type, T>::value);

--- a/number_theory/numeric.h
+++ b/number_theory/numeric.h
@@ -21,7 +21,7 @@ using std::lcm;
 // Extended Euclidean algorithm.
 // Given two numbers |a| and |b|, returns a pair (x, y) satisfying
 // x*a + y*b == gcd(a,b).
-template <class T>
+template <typename T>
 std::pair<T, T> exgcd(T a, T b) {
   static_assert(
       std::numeric_limits<T>::is_integer && std::numeric_limits<T>::is_signed,
@@ -52,8 +52,8 @@ std::pair<T, T> exgcd(T a, T b) {
 // Computes the value of |base| raised to an integer power |exponent|.
 // This version of overload uses binary exponentiation technique to compute in
 // O(log |exponent|) time.
-template <class T,
-          class U,
+template <typename T,
+          typename U,
           std::enable_if_t<std::numeric_limits<U>::is_integer, bool> = true>
 T pow(const T &base, U exponent) {
   using Pair_TT = std::pair<T, T>;
@@ -81,8 +81,8 @@ T pow(const T &base, U exponent) {
 
 // Computes the value of |base| raised to a non-integer power |exponent|.
 // This version of overload is the same as std::pow.
-template <class T,
-          class U,
+template <typename T,
+          typename U,
           std::enable_if_t<!std::numeric_limits<U>::is_integer, bool> = true>
 auto pow(T base, U exponent) -> decltype(std::pow(base, exponent)) {
   return std::pow(base, exponent);

--- a/number_theory/numeric_unittest.cpp
+++ b/number_theory/numeric_unittest.cpp
@@ -12,7 +12,7 @@
 namespace tql {
 namespace number_theory {
 
-template <class T>
+template <typename T>
 void test_exgcd(T a, T b) {
   auto [x, y] = exgcd(a, b);
   if (a != 0 && b != 0) {

--- a/number_theory/prime.h
+++ b/number_theory/prime.h
@@ -13,7 +13,7 @@ namespace number_theory {
 //
 // This overload is only available for numbers smaller than 2^16 since it
 // performs poorly for large numbers.
-template <class T,
+template <typename T,
           std::enable_if_t<std::numeric_limits<T>::is_integer &&
                                std::numeric_limits<T>::digits <= 16,
                            bool> = true>

--- a/number_theory/utility.h
+++ b/number_theory/utility.h
@@ -15,7 +15,7 @@ namespace number_theory {
 // For each bit of |binary|, from lower to higher, it applies |operation| to
 // accumulate the values. The initial value is |initial_value|.
 // As an example, when |operation| is addition, it becomes a popcount.
-template <class T, class U>
+template <typename T, typename U>
 U binary_accumulate(T binary,
                     const U &initial_value,
                     std::function<void(bool, U &)> operation) {
@@ -36,7 +36,7 @@ U binary_accumulate(T binary,
 // If x = 0, sign(x) = 0.
 // If x > 0, sign(x) = 1.
 // If x < 0, sign(x) = -1.
-template <class T>
+template <typename T>
 constexpr int sign(T x) {
   if (x == 0)
     return 0;
@@ -47,7 +47,7 @@ constexpr int sign(T x) {
 //
 // This can be useful because std::abs doesn't support unsigned integers, and
 // std::abs(std::numeric_limits<T>::min()) is undefined.
-template <class T>
+template <typename T>
 constexpr std::make_unsigned_t<T> unsigned_abs(T x) {
   static_assert(std::numeric_limits<T>::is_integer,
                 "unsigned_abs argument |x| must be an integer.");


### PR DESCRIPTION
Use `<typename T>` instead of `<class T>` in template argument list, because
it is more common.