### PR TITLE
Prefer internal namespace over unnamed namespace

### DIFF
--- a/number_theory/modular.h
+++ b/number_theory/modular.h
@@ -13,8 +13,7 @@
 
 namespace tql {
 namespace number_theory {
-
-namespace {
+namespace internal {
 
 // Returns the equivalent element of |x| in the ring of integers modulo
 // |modulus|. The result |y| should statisfy 0 <= y < modulus, and
@@ -38,9 +37,9 @@ struct ModulusWrapper {
   constexpr ModulusWrapper(T x) : value(std::move(x)) {}
 };
 
-}  // namespace
+}  // namespace internal
 
-template <ModulusWrapper mod>
+template <internal::ModulusWrapper mod>
 class Modular {
  public:
   using type = std::decay_t<typename decltype(mod)::type>;
@@ -64,7 +63,9 @@ class Modular {
 
   const type &get() const { return value_; }
 
-  void set(type value) { value_ = normalize(std::move(value), modulus); }
+  void set(type value) {
+    value_ = internal::normalize(std::move(value), modulus);
+  }
 
   Modular add(const Modular &rhs) const {
     check_addition_overflow();

--- a/number_theory/modular.h
+++ b/number_theory/modular.h
@@ -13,6 +13,7 @@
 
 namespace tql {
 namespace number_theory {
+
 namespace internal {
 
 // Returns the equivalent element of |x| in the ring of integers modulo

--- a/number_theory/modular.h
+++ b/number_theory/modular.h
@@ -14,7 +14,7 @@
 namespace tql {
 namespace number_theory {
 
-namespace internal {
+namespace modular_internal {
 
 // Returns the equivalent element of |x| in the ring of integers modulo
 // |modulus|. The result |y| should statisfy 0 <= y < modulus, and
@@ -38,9 +38,9 @@ struct ModulusWrapper {
   constexpr ModulusWrapper(T x) : value(std::move(x)) {}
 };
 
-}  // namespace internal
+}  // namespace modular_internal
 
-template <internal::ModulusWrapper mod>
+template <modular_internal::ModulusWrapper mod>
 class Modular {
  public:
   using type = std::decay_t<typename decltype(mod)::type>;
@@ -65,7 +65,7 @@ class Modular {
   const type &get() const { return value_; }
 
   void set(type value) {
-    value_ = internal::normalize(std::move(value), modulus);
+    value_ = modular_internal::normalize(std::move(value), modulus);
   }
 
   Modular add(const Modular &rhs) const {


### PR DESCRIPTION
The unnamed namespace will also be exposed to the user, because the
namespace is defined in the header file and the user includes it. This
commit replaces unnamed namespace with an internal namespace.