### PR TITLE
Include stdexcept in utility.h

### DIFF
--- a/number_theory/utility.h
+++ b/number_theory/utility.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <limits>
+#include <stdexcept>
 #include <type_traits>
 
 // Public utility functions.


### PR DESCRIPTION
We need to include stdexcept because numeric_cast needs std::range_error.