### PR TITLE
Allow clang-tidy workflow to run on forks

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -1,10 +1,15 @@
 name: clang-tidy
 
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   job:
     runs-on: ubuntu-latest
+
+    # Since pull_request_target is not safe, this job requires approval before running.
+    # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    environment:
+      name: Privileged Environment
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Lint with clang-tidy.
         uses: ZedThree/clang-tidy-review@v0.8.2


### PR DESCRIPTION
In order to allow clang-tidy-review action to put comments on PRs, we
need to share the github token. This can be achieved by using
pull_request_target event instead of pull_request event. However,
sharing the token with an unknown fork can be dangerous since it grants
them write access. Therefore, the job needs to be approved before it is
executed.