### PR TITLE
Run clang-tidy in merged commit

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{github.event.pull_request.number}}/merge
 
       - name: Lint with clang-tidy.
         uses: ZedThree/clang-tidy-review@v0.8.2


### PR DESCRIPTION
Check the merged commit instead of the pull request's commit itself. It
is the default behavior of the pull_request event. But here we are using
pull_request_target, so a special checkout to the merged commit is needed.